### PR TITLE
Asset Render After Load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 2.2.1 [Asset Render After Load]
+
+- Stickers & Wallpapers will now render after the IDE finishes loading all of the background tasks. See [#33](https://github.com/doki-theme/doki-theme-visualstudio/pull/33) for more details.
+
 # 2.2.0 [Wallpaper Positioning]
 
 - Added several wallpaper related settings, see [#30](https://github.com/doki-theme/doki-theme-visualstudio/pull/30) for more details.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Doki Theme: Visual Studio
     - [Offline Mode](#offline-mode)
     - [Stickers](#stickers)
     - [Wallpaper](#wallpapers)
+  - [Weird Bugs](#weird-bugs)
 - [Miscellaneous](#miscellaneous)
     - [Contributing](#contributing) 
     - [Theme Requests](#theme-requests)
@@ -120,6 +121,14 @@ You can always set it back to `-1` and you'll get the default opacity that I pic
 | **WallpaperOpacity**: `-1` | **WallpaperOpacity**: `0.25` |
 | --- | --- |
 | ![default opacity](readmeAssets/screens/opacity_def.png) |  ![default opacity](readmeAssets/screens/opacity_quarter.png) |
+
+## Weird Bugs
+
+The assets will only show up after the package initializes. This takes a bit longer if a solution is opened instead of the regular launch screen (the one where you you can open a project from). The plugin loads quicker on the launch screen. 
+
+I couldn't figure out how to re-render the window, so the sticker/wallpaper will only show up after scrolling/typing/switching tabs. So just keep coding and your stuff will eventually show up.
+
+https://user-images.githubusercontent.com/15972415/145320920-9492b4d1-ae46-43f2-b65f-1ee7d02c5a19.mp4
 
 # Miscellaneous
 

--- a/buildSrc/buildThemes.bat
+++ b/buildSrc/buildThemes.bat
@@ -11,10 +11,10 @@
 @REM yarn buildThemes 83e94920-9ae2-4838-9b85-4c3fa22b67b8
 
 @REM Maple Light
-@REM yarn buildThemes ea7a8b00-2d86-4e06-81a2-5c14a46264d5
+yarn buildThemes ea7a8b00-2d86-4e06-81a2-5c14a46264d5
 
 @REM Jahy
-yarn buildThemes 91d0931d-3e1d-4101-b923-278ce264f0f5
+@REM yarn buildThemes 91d0931d-3e1d-4101-b923-278ce264f0f5
 
 @REM Shigure
 @REM yarn buildThemes 67278007-b7f8-46d4-88b7-e40cac3576a7

--- a/doki-theme-visualstudio/StickerAdornmentTextViewCreationListener.cs
+++ b/doki-theme-visualstudio/StickerAdornmentTextViewCreationListener.cs
@@ -36,13 +36,15 @@ namespace doki_theme_visualstudio {
     /// <param name="textView">The <see cref="IWpfTextView" /> upon which the adornment should be placed</param>
     public void TextViewCreated(IWpfTextView textView) {
       // The adornment will get wired to the text view events
-      if (SettingsService.IsInitialized()) {
+      if (TheDokiTheme.IsInitialized()) {
         new StickerAdornment(textView);
       } else {
-        Task.Run(async () => {
-          await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-          new StickerAdornment(textView);
-        }).FileAndForget("dokiTheme/stickerLoad");
+        TheDokiTheme.PluginInitialized += (_, __) => {
+          Task.Run(async () =>{
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            new StickerAdornment(textView);
+          }).FileAndForget("dokiTheme/stickerLoad");
+        };
       }
     }
   }

--- a/doki-theme-visualstudio/TheDokiTheme.cs
+++ b/doki-theme-visualstudio/TheDokiTheme.cs
@@ -1,9 +1,16 @@
+using System;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
 
 namespace doki_theme_visualstudio {
   public static class TheDokiTheme {
+
+    private static bool _isInitialized = false;
+    public static bool IsInitialized() => _isInitialized;
+
+    public static event EventHandler<string>? PluginInitialized;
+
     public static async Task InitializePluginAsync(AsyncPackage package, CancellationToken cancellationToken) {
       ThreadHelper.ThrowIfOnUIThread();
       
@@ -13,6 +20,8 @@ namespace doki_theme_visualstudio {
       
       // depends on local storage service
       LocalAssetService.Init(package);
+      _isInitialized = true;
+      PluginInitialized?.Invoke(null, "Dun!");
     }
   }
 }

--- a/doki-theme-visualstudio/WallpaperAdornmentTextViewCreationListener.cs
+++ b/doki-theme-visualstudio/WallpaperAdornmentTextViewCreationListener.cs
@@ -34,13 +34,15 @@ namespace doki_theme_visualstudio {
     /// </summary>
     /// <param name="textView">The <see cref="IWpfTextView"/> upon which the adornment should be placed</param>
     public void TextViewCreated(IWpfTextView textView) {
-      if (SettingsService.IsInitialized()) {
+      if (TheDokiTheme.IsInitialized()) {
         new WallpaperAdornment(textView);
       } else {
-        Task.Run(async () => {
-          await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-          new WallpaperAdornment(textView);
-        }).FileAndForget("dokiTheme/wallpaperLoad");
+        TheDokiTheme.PluginInitialized += (_, __) =>  {
+          Task.Run(async () =>{
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            new WallpaperAdornment(textView);
+          }).FileAndForget("dokiTheme/wallpaperLoad");
+        };
       }
     }
   }

--- a/doki-theme-visualstudio/source.extension.vsixmanifest
+++ b/doki-theme-visualstudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="doki_theme_visualstudio.59d36e38-60e0-4571-9901-7971ec61b303" Version="2.2.0" Language="en-US" Publisher="Unthrottled" />
+        <Identity Id="doki_theme_visualstudio.59d36e38-60e0-4571-9901-7971ec61b303" Version="2.2.1" Language="en-US" Publisher="Unthrottled" />
         <DisplayName>The Doki Theme</DisplayName>
         <Description xml:space="preserve">Code with your Waifu!</Description>
         <MoreInfo>https://github.com/doki-theme/doki-theme-visualstudio#the-doki-theme-visual-studio</MoreInfo>


### PR DESCRIPTION
## Changes

- Stickers & Wallpapers will now render after the IDE finishes loading all of the background tasks.

## Motivation

Small brain fix for closing #6 

## Notes:

The assets will only show up after the package initializes. This takes a bit longer if a solution is opened instead of the regular launch screen (the one where you you can open a project from). The plugin loads quicker on the launch screen. 

I couldn't figure out how to re-render the window, so the sticker/wallpaper will only show up after scrolling/typing/switching tabs. So just keep coding and your stuff will eventually show up.

https://user-images.githubusercontent.com/15972415/145320920-9492b4d1-ae46-43f2-b65f-1ee7d02c5a19.mp4


