### PR TITLE
Tab Layout Header Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 78.0-1.0.1 [Themed Tab Layout]
+
+- Themed the tab layout title to match the rest of the IDE.
+
 # 78.0-1.0.0 [The Boys]
 
 I'm trying to bring in a bit of inclusion.

--- a/buildSrc/assets/templates/DokiDark.v2.vstheme.template
+++ b/buildSrc/assets/templates/DokiDark.v2.vstheme.template
@@ -2931,11 +2931,14 @@
       <Color Name="FileTabActiveGroupBackground">
         <Background Source="FF{{textEditorBackground}}" Type="CT_RAW"/>
       </Color>
-      <Color Name="FileTabActiveGroupTitleBackground">
-        <Background Source="FF0D4F82" Type="CT_RAW"/>
-      </Color>
       <Color Name="FileTabBackground">
         <Background Source="FF{{textEditorBackground}}" Type="CT_RAW"/>
+      </Color>
+      <Color Name="FileTabActiveGroupTitleBackground">
+        <Background Source="FF{{headerColor}}" Type="CT_RAW"/>
+      </Color>        
+      <Color Name="FileTabPrimarySeparator">
+        <Background Source="FF{{headerColor}}" Type="CT_RAW"/>
       </Color>
       <Color Name="FileTabBorder">
         <Background Source="FF{{borderColor}}" Type="CT_RAW"/>
@@ -3155,9 +3158,6 @@
       </Color>
       <Color Name="FileTabParentText">
         <Background Source="FF{{foregroundColor}}" Type="CT_RAW"/>
-      </Color>
-      <Color Name="FileTabPrimarySeparator">
-        <Background Source="FFA8B3C2" Type="CT_RAW"/>
       </Color>
       <Color Name="FileTabProvisionalHover">
         <Background Source="FF{{diff.deleted}}" Type="CT_RAW"/>

--- a/buildSrc/assets/templates/DokiDark.v2.vstheme.template
+++ b/buildSrc/assets/templates/DokiDark.v2.vstheme.template
@@ -3157,7 +3157,7 @@
         <Background Source="FF{{highlightColor}}" Type="CT_RAW"/>
       </Color>
       <Color Name="FileTabParentText">
-        <Background Source="FF{{foregroundColor}}" Type="CT_RAW"/>
+        <Background Source="FF{{infoForeground}}" Type="CT_RAW"/>
       </Color>
       <Color Name="FileTabProvisionalHover">
         <Background Source="FF{{diff.deleted}}" Type="CT_RAW"/>

--- a/buildSrc/assets/templates/DokiLight.vstheme.template
+++ b/buildSrc/assets/templates/DokiLight.vstheme.template
@@ -3032,6 +3032,12 @@
         </Color>
         <Color Name="FileTabBackground">
           <Background Source="FF{{textEditorBackground}}" Type="CT_RAW"/>
+        </Color>        
+        <Color Name="FileTabActiveGroupTitleBackground">
+          <Background Source="FF{{headerColor}}" Type="CT_RAW"/>
+        </Color>        
+        <Color Name="FileTabPrimarySeparator">
+          <Background Source="FF{{headerColor}}" Type="CT_RAW"/>
         </Color>
         <Color Name="FileTabBorder">
           <Background Source="FF{{borderColor}}" Type="CT_RAW"/>

--- a/buildSrc/assets/templates/DokiLight.vstheme.template
+++ b/buildSrc/assets/templates/DokiLight.vstheme.template
@@ -3202,7 +3202,7 @@
           <Background Source="FF{{highlightColor}}" Type="CT_RAW"/>
         </Color>
         <Color Name="FileTabParentText">
-          <Background Source="FF{{foregroundColor}}" Type="CT_RAW"/>
+          <Background Source="FF{{infoForeground}}" Type="CT_RAW"/>
         </Color>
         <Color Name="FileTabProvisionalHover">
           <Background Source="AA{{highlightColor}}" Type="CT_RAW"/>

--- a/doki-theme-visualstudio/source.extension.vsixmanifest
+++ b/doki-theme-visualstudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="doki_theme_visualstudio.59d36e38-60e0-4571-9901-7971ec61b303" Version="78.1.0" Language="en-US" Publisher="Unthrottled" />
+        <Identity Id="doki_theme_visualstudio.59d36e38-60e0-4571-9901-7971ec61b303" Version="78.1.1" Language="en-US" Publisher="Unthrottled" />
         <DisplayName>The Doki Theme</DisplayName>
         <Description xml:space="preserve">Cute anime character themes!</Description>
         <MoreInfo>https://github.com/doki-theme/doki-theme-visualstudio#the-doki-theme-visual-studio</MoreInfo>


### PR DESCRIPTION
# Changes

- Themed the tab layout title to match the rest of the IDE.

# Motivation

Closes #43 

# Screens

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/15972415/163888598-6651de5d-6313-42ee-b79a-ed56507c26cb.png) | ![image](https://user-images.githubusercontent.com/15972415/163888616-a9fb6e2e-5101-4bc6-b9c8-d1d7a7a27d18.png) |

