### PR TITLE
Restored themed XAML view background.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---
 
+# 78.0-1.0.2 [Themed XAML Views]
+
+- Restored the original intended background color of the `XAML` view. ([#22](https://github.com/doki-theme/doki-theme-visualstudio/issues/21))
+
 # 78.0-1.0.1 [Themed Tab Layout]
 
 - Themed the tab layout title to match the rest of the IDE.

--- a/doki-theme-visualstudio/UITools.cs
+++ b/doki-theme-visualstudio/UITools.cs
@@ -10,14 +10,21 @@ namespace doki_theme_visualstudio {
       Func<DependencyObject, bool> predicate
     ) {
       while (true) {
-        var parent = childDependencyObject is Visual || childDependencyObject is Visual3D
-          ? VisualTreeHelper.GetParent(childDependencyObject)
-          : LogicalTreeHelper.GetParent(childDependencyObject);
+        var parent = GetParent(childDependencyObject);
         if (parent == null) return null;
 
         if (predicate(parent)) return parent;
         childDependencyObject = parent;
       }
+    }
+
+    public static DependencyObject? GetParent(
+      DependencyObject childDependencyObject
+    ) {
+      var parent = childDependencyObject is Visual || childDependencyObject is Visual3D
+        ? VisualTreeHelper.GetParent(childDependencyObject)
+        : LogicalTreeHelper.GetParent(childDependencyObject);
+      return parent;
     }
 
     public static void TraverseParentTree(

--- a/doki-theme-visualstudio/source.extension.vsixmanifest
+++ b/doki-theme-visualstudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="doki_theme_visualstudio.59d36e38-60e0-4571-9901-7971ec61b303" Version="78.1.1" Language="en-US" Publisher="Unthrottled" />
+        <Identity Id="doki_theme_visualstudio.59d36e38-60e0-4571-9901-7971ec61b303" Version="78.1.2" Language="en-US" Publisher="Unthrottled" />
         <DisplayName>The Doki Theme</DisplayName>
         <Description xml:space="preserve">Cute anime character themes!</Description>
         <MoreInfo>https://github.com/doki-theme/doki-theme-visualstudio#the-doki-theme-visual-studio</MoreInfo>


### PR DESCRIPTION
## Changes

- Setting the Editor to the themed opaque colored background and drawing the background image on the first child that will accept a background image.

## Motivation

Fixes #22  and probably #45 

## Screen

![image](https://user-images.githubusercontent.com/15972415/166315306-2601e6e8-f290-4a4c-98e5-f23f0d518327.png)

